### PR TITLE
Closes EZB-25, EZB-22 Feature/DIContainer, Fix: Entity 오류

### DIFF
--- a/EzyBook/APP/EzyBookApp.swift
+++ b/EzyBook/APP/EzyBookApp.swift
@@ -9,9 +9,13 @@ import SwiftUI
 
 @main
 struct EzyBookApp: App {
+    
+    @StateObject var container = AppDIContainer().makeDIContainer()
+    
     var body: some Scene {
         WindowGroup {
             MainTabView()
+                .environmentObject(container)
         }
     }
 }

--- a/EzyBook/Core/DIContainer/AppDIContainer.swift
+++ b/EzyBook/Core/DIContainer/AppDIContainer.swift
@@ -1,0 +1,17 @@
+//
+//  AppDIContainer.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/14/25.
+//
+
+import Foundation
+
+final class AppDIContainer {
+    func makeDIContainer() -> DIContainer {
+        let networkManger = NetworkService()
+        let decoder = ResponseDecoder()
+        
+        return DIContainer(networkManger: networkManger, decodingManger: decoder)
+    }
+}

--- a/EzyBook/Core/DIContainer/DIContainer.swift
+++ b/EzyBook/Core/DIContainer/DIContainer.swift
@@ -1,0 +1,28 @@
+//
+//  DIContainer.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/14/25.
+//
+
+import Foundation
+
+///
+/// 공통 모듈
+/// 네트워크 서비스?, 저장소 패턴, 또 뭐가 있을끼?
+
+final class DIContainer: ObservableObject {
+
+    private let networkManger: NetworkService
+    private let decodingManger: ResponseDecoder
+    
+    init(networkManger: NetworkService, decodingManger: ResponseDecoder) {
+        self.networkManger = networkManger
+        self.decodingManger = decodingManger
+    }
+
+    func makeNetworkRepository() -> NetworkRepository {
+        return NetworkRepository(networkManger: networkManger, decodingManager: decodingManger)
+    }
+    
+}

--- a/EzyBook/Core/Data/DTO/Protocol/EntityConvertible.swift
+++ b/EzyBook/Core/Data/DTO/Protocol/EntityConvertible.swift
@@ -1,0 +1,13 @@
+//
+//  EntityConvertible.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/14/25.
+//
+
+import Foundation
+
+protocol EntityConvertible {
+    associatedtype T
+    func toEntity() -> T
+}

--- a/EzyBook/Core/Data/DTO/User/UserRequestDTO.swift
+++ b/EzyBook/Core/Data/DTO/User/UserRequestDTO.swift
@@ -42,3 +42,4 @@ struct AppleLoginRequestDTO: Encodable {
     let deviceToken: String?
     let nick: String?
 }
+

--- a/EzyBook/Core/Data/DTO/User/UserResponseDTO.swift
+++ b/EzyBook/Core/Data/DTO/User/UserResponseDTO.swift
@@ -43,7 +43,7 @@ struct ProfileCheckResponseDTO: Decodable {
 
 // MARK: Post(Response)
 /// 이메일 유효성 검사
-struct EmailValidationResponseDTO: Decodable {
+struct EmailValidationResponseDTO: Decodable, EntityConvertible {
     let message: String
 }
 
@@ -83,4 +83,14 @@ struct LoginResponseDTO: Encodable {
         case refreshToken
     }
     
+}
+
+
+// MARK: UserReponseDTO Extension
+
+extension EmailValidationResponseDTO {
+    
+    func toEntity() -> EmailValidationEntity {
+        return EmailValidationEntity(message: self.message)
+    }
 }

--- a/EzyBook/Core/Entity/Protocol/StructEntity.swift
+++ b/EzyBook/Core/Entity/Protocol/StructEntity.swift
@@ -1,0 +1,12 @@
+//
+//  StructEntity.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/14/25.
+//
+
+import Foundation
+
+/// 구조체 Entity를 위한 프로토콜
+/// 기능은 따로 없음
+protocol StructEntity {}

--- a/EzyBook/Core/Entity/User/UserEntity.swift
+++ b/EzyBook/Core/Entity/User/UserEntity.swift
@@ -1,0 +1,12 @@
+//
+//  UserEntity.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/14/25.
+//
+
+import Foundation
+
+struct EmailValidationEntity: StructEntity {
+    let message: String
+}

--- a/EzyBook/Core/Interface/Network/EzyBookNetworkRepository.swift
+++ b/EzyBook/Core/Interface/Network/EzyBookNetworkRepository.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol EzyBookNetworkRepository {
-    func fetchData<T: Decodable ,R: NetworkRouter>(_ router: R, completionHandler: @escaping (Result<T, APIErrorResponse>) -> Void)
+    func fetchData<T: Decodable & EntityConvertible, E: StructEntity ,R: NetworkRouter>(dto: T.Type, _ router: R, completionHandler: @escaping (Result<E, APIErrorResponse>) -> Void) where T.T == E
 }

--- a/EzyBook/Features/TapView/MainTabView.swift
+++ b/EzyBook/Features/TapView/MainTabView.swift
@@ -16,6 +16,8 @@ struct MainTabView: View {
     
     @State private var selectedTab: Tab = .profile
     
+    @EnvironmentObject var container: DIContainer
+    
     var body: some View {
         TabView(selection: $selectedTab) {
             ProfileView()
@@ -24,6 +26,7 @@ struct MainTabView: View {
                     
                     
                 }
+                .environmentObject(container)
                 .tag(Tab.profile)
         }
     }

--- a/EzyBook/Features/TapView/Profile/View/ProfileView.swift
+++ b/EzyBook/Features/TapView/Profile/View/ProfileView.swift
@@ -43,7 +43,7 @@ struct ProfileView: View {
         
         let requestDTO = EmailValidationRequestDTO(email: "sesddddac_re_jack@gmail.com")
         let networkRepository = container.makeNetworkRepository()
-        networkRepository.fetchData(UserRequest.emailValidation(body: requestDTO)) { (result: Result<EmailValidationResponseDTO, APIErrorResponse>) in
+        networkRepository.fetchData(dto: EmailValidationResponseDTO.self, UserRequest.emailValidation(body: requestDTO)) { (result: Result<EmailValidationEntity, APIErrorResponse>) in
             
             switch result {
             case .success(let success):

--- a/EzyBook/Features/TapView/Profile/View/ProfileView.swift
+++ b/EzyBook/Features/TapView/Profile/View/ProfileView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ProfileView: View {
     
     @State private var showModal = false
-    
+    @EnvironmentObject var container: DIContainer
     
     var body: some View {
         VStack {
@@ -41,11 +41,9 @@ struct ProfileView: View {
     }
     private func test() {
         
-        
-        let test = NetworkRepository(networkManger: NetworkService(), decodingManager: ResponseDecoder())
         let requestDTO = EmailValidationRequestDTO(email: "sesddddac_re_jack@gmail.com")
-        
-        test.fetchData(UserRequest.emailValidation(body: requestDTO)) { (result: Result<EmailValidationResponseDTO, APIErrorResponse>) in
+        let networkRepository = container.makeNetworkRepository()
+        networkRepository.fetchData(UserRequest.emailValidation(body: requestDTO)) { (result: Result<EmailValidationResponseDTO, APIErrorResponse>) in
             
             switch result {
             case .success(let success):
@@ -54,6 +52,8 @@ struct ProfileView: View {
                 print(failure)
             }
         }
+        
+     
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #EZB-25, EZB-22 

## 📝작업 내용

> Di Container 적용
아직 모든 설계가 끝나지 않았으며 런타임 시점에 의존성을 변경할 수도 있기 때문에, 클래스 선택
스유에서는 Enviroment를 사용할 수 있기 때문에, 생성자 주입보다는 Enviromnet를 사용
생성자 주입시에는 DiContainer가 ObservableObject를 채택하지 않아도 되지만, 프롭 드릴링이 발생하기 때문에,
불필요한 생성자 주입이 발생할 수 있음

> 저장소에서 현재 DTO로 디코딩은 가능하나, EntIty로는 리턴이 불가능
- 제네릭을 하나 더 추가하여 개선

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
-> 고려사항: 제네릭이 계속 추가되는게 과연 좋을까?

## ✅CheckList
- [X] 컨벤션 준수하셨나요?
- [X] 불필요한 주석 제거하셨나요?
- [X] 단일 책임 원칙을 지키셨나요?
