### PR TITLE
Close EZB-26 fix/네트워크통신-에러코드메시지-수정

### DIFF
--- a/EzyBook/Core/Data/Common/RequestEncoder.swift
+++ b/EzyBook/Core/Data/Common/RequestEncoder.swift
@@ -14,7 +14,7 @@ struct URLQueryEncoder {
     func encode(request: URLRequest, with requestBody: Encodable?) throws -> URLRequest {
         
         guard let body = requestBody else {
-            throw APIError.missingRequestBody
+            throw APIError(localErrorType: .missingEndpoint)
         }
         
         return try JSONParameterEncoder.default.encode(body, into: request)

--- a/EzyBook/Core/Data/Common/ResponseDecoder.swift
+++ b/EzyBook/Core/Data/Common/ResponseDecoder.swift
@@ -14,7 +14,8 @@ struct ResponseDecoder {
             let decoded = try JSONDecoder().decode(T.self, from: data)
             return .success(decoded)
         } catch {
-            return .failure(.unknown)
+            let error = APIError(localErrorType: .decodingError)
+            return .failure(error)
         }
     }
 }

--- a/EzyBook/Core/Data/Repository/NetworkRepository.swift
+++ b/EzyBook/Core/Data/Repository/NetworkRepository.swift
@@ -17,7 +17,7 @@ final class NetworkRepository: EzyBookNetworkRepository {
         self.decodingManager = decodingManager
     }
     
-    func fetchData<T: Decodable & EntityConvertible, E: StructEntity, R: NetworkRouter>(dto: T.Type ,_ router: R, completionHandler: @escaping (Result<E, APIErrorResponse>) -> Void) where T.T == E {
+    func fetchData<T: Decodable & EntityConvertible, E: StructEntity, R: NetworkRouter>(dto: T.Type ,_ router: R, completionHandler: @escaping (Result<E, APIError>) -> Void) where T.T == E {
         
         networkManger.request(router) { (result: Result<Data, APIError>) in
                         
@@ -29,20 +29,15 @@ final class NetworkRepository: EzyBookNetworkRepository {
                 case .success(let success):
                     let entity = success.toEntity()
                     completionHandler(.success(entity))
-                case .failure:
-                    let responseCode = APIError(statusCode: 10002)
-                    let error = APIErrorResponse.api(responseCode.rawValue, message: responseCode.defaultMessage)
+                case .failure(let error):
                     completionHandler(.failure(error))
                 }
                 
-            case .failure(let failure):
-                let error = APIErrorResponse.api(failure.rawValue, message: failure.defaultMessage)
+            case .failure(let error):
                 completionHandler(.failure(error))
             }
         }
     }
-    
-    
     
 }
     

--- a/EzyBook/Core/Interface/Network/EzyBookNetworkRepository.swift
+++ b/EzyBook/Core/Interface/Network/EzyBookNetworkRepository.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol EzyBookNetworkRepository {
-    func fetchData<T: Decodable & EntityConvertible, E: StructEntity ,R: NetworkRouter>(dto: T.Type, _ router: R, completionHandler: @escaping (Result<E, APIErrorResponse>) -> Void) where T.T == E
+    func fetchData<T: Decodable & EntityConvertible, E: StructEntity ,R: NetworkRouter>(dto: T.Type, _ router: R, completionHandler: @escaping (Result<E, APIError>) -> Void) where T.T == E
 }

--- a/EzyBook/Core/Interface/Network/NetworkRouter.swift
+++ b/EzyBook/Core/Interface/Network/NetworkRouter.swift
@@ -26,7 +26,7 @@ extension NetworkRouter {
     /// Helper Function (프로토콜 추가할 필요가 없음)
     func makeURLRequest() throws -> URLRequest {
         guard let url = endpoint else {
-            throw APIError.missingEndpoint
+            throw APIError(localErrorType: .missingEndpoint)
         }
         var request = URLRequest(url: url)
         request.method = method

--- a/EzyBook/Core/Interface/Network/PostRouter.swift
+++ b/EzyBook/Core/Interface/Network/PostRouter.swift
@@ -24,7 +24,7 @@ extension PostRouter {
     /// POST 요청 특화 처리 (body)
     func encodeBody(for request: URLRequest) throws -> URLRequest {
         guard let body = requestBody else {
-            throw APIError.missingRequestBody
+            throw APIError(localErrorType: .missingRequestBody)
         }
         return try encoder.encode(request: request, with: body)
     }

--- a/EzyBook/Core/NetworkManager/Common/APIError.swift
+++ b/EzyBook/Core/NetworkManager/Common/APIError.swift
@@ -7,64 +7,83 @@
 
 import Foundation
 
-enum RequestType {
-    case auth
-    case user
-}
-
-
-enum APIError: Int, Error {
-    case requiredFieldMissing = 400 // 필수값이 없을 때
-    case invalidRefreshToken = 401 // 인증할 수 없는 리프레시 토큰 // 계정 확인
-    case emailUnavailable = 409 // 사용 불가능한 이메일 또는 이미 가입된 유저
-    case expiredRefreshToken = 418 // 토큰 만료
-    case unknown
+enum APIError: Error {
+    // 서버 에러 (HTTP 상태 코드 기반)
+    case serverError(code: Int, message: String?)
     
-    case missingEndpoint = 10000
-    case missingRequestBody = 10001
-    case decodingError = 10002
+    // 로컬 에러 (클라이언트 측)
+    case localError(type: LocalErrorType, message: String?)
     
+    // 원시 데이터가 있는 에러 (파싱이 필요한 경우)
+    case dataError(code: Int, data: Data?)
     
-    
-    init(statusCode: Int) {
-         self = APIError(rawValue: statusCode) ?? .unknown
-     }
-    
-    var defaultMessage: String {
-        switch self {
-        case .requiredFieldMissing:
-            return "필수값을 채워주세요."
-        case .invalidRefreshToken:
-            return "토큰 또는 계정을 확인해주세요."
-        case .emailUnavailable:
-            return "이미 가입된 유저거나, 사용 불가능한 이메일입니다."
-        case .expiredRefreshToken:
-            return "토큰이 만료되었습니다."
-        case .unknown:
-            return "관리자 요청: 알 수 없는 오류."
-        case .missingEndpoint:
-            return "endPoint를 확인해주세요."
-        case .missingRequestBody:
-            return "요청 바디가 유효하지 않습니다."
-        case .decodingError:
-            return "디코딩 타입을 확인해주세요." 
-        }
+    // 로컬 에러 타입
+    enum LocalErrorType: Int {
+        case missingEndpoint = 10000
+        case missingRequestBody = 10001
+        case decodingError = 10002
+        // 기타 로컬 에러 타입
     }
-}
-
-extension APIError {
-    func message(for context: RequestType) -> String {
-        switch (self, context) {
-        case (.invalidRefreshToken, .auth):
-            return "인증할 수 없는 리프레시 토큰입니다."
-        case (.invalidRefreshToken, .user):
-            return "계정을 확인해주세요."
+    
+    // HTTP 상태 코드에서 생성
+    init(statusCode: Int, data: Data? = nil) {
+        // data가 있으면 dataError로 처리
+        if let data = data {
+            self = .dataError(code: statusCode, data: data)
+            return
+        }
+        
+        switch statusCode {
+        case 400:
+            self = .serverError(code: statusCode, message: "필수값을 채워주세요.")
+        case 401:
+            self = .serverError(code: statusCode, message: "토큰 또는 계정을 확인해주세요.")
+        case 409:
+            self = .serverError(code: statusCode, message: "이미 가입된 유저거나, 사용 불가능한 이메일입니다.")
+        case 418:
+            self = .serverError(code: statusCode, message: "토큰이 만료되었습니다.")
         default:
-            return self.defaultMessage
+            self = .serverError(code: statusCode, message: "알 수 없는 오류가 발생했습니다.")
         }
     }
-}
-/// 문자열을 보내기 위한 Error 추가
-enum APIErrorResponse: Error {
-    case api(_ responseCode: Int, message: String)
+    
+    // 로컬 에러 타입에서 생성
+    init(localErrorType: LocalErrorType) {
+        switch localErrorType {
+        case .missingEndpoint:
+            self = .localError(type: localErrorType, message: "endPoint를 확인해주세요.")
+        case .missingRequestBody:
+            self = .localError(type: localErrorType, message: "요청 바디가 유효하지 않습니다.")
+        case .decodingError:
+            self = .localError(type: localErrorType, message: "디코딩 타입을 확인해주세요.")
+        }
+    }
+    
+    // 에러 코드
+    var code: Int {
+        switch self {
+        case .serverError(let code, _):
+            return code
+        case .localError(let type, _):
+            return type.rawValue
+        case .dataError(let code, _):
+            return code
+        }
+    }
+    
+    // 사용자에게 보여줄 메시지
+    var userMessage: String {
+        switch self {
+        case .serverError(_, let message):
+            return message ?? "서버 오류가 발생했습니다."
+        case .localError(_, let message):
+            return message ?? "앱 오류가 발생했습니다."
+        case .dataError(_, let data):
+            if let data = data, let errorResponse = try? JSONDecoder().decode(ErrorMessageDTO.self, from: data) {
+                return errorResponse.message //?? "서버에서 오류가 발생했습니다."
+            }
+            return "오류가 발생했습니다."
+        }
+    }
+    
 }

--- a/EzyBook/Core/NetworkManager/Common/APIError.swift
+++ b/EzyBook/Core/NetworkManager/Common/APIError.swift
@@ -79,8 +79,16 @@ enum APIError: Error {
         case .localError(_, let message):
             return message ?? "앱 오류가 발생했습니다."
         case .dataError(_, let data):
-            if let data = data, let errorResponse = try? JSONDecoder().decode(ErrorMessageDTO.self, from: data) {
-                return errorResponse.message //?? "서버에서 오류가 발생했습니다."
+
+            if let data = data {
+                let decoder = ResponseDecoder()
+                let errorResponse = decoder.decode(data: data, type: ErrorMessageDTO.self)
+                switch errorResponse {
+                case .success(let success):
+                    return success.message
+                case .failure(let error):
+                    return error.userMessage
+                }
             }
             return "오류가 발생했습니다."
         }

--- a/EzyBook/Core/NetworkManager/NetworkService.swift
+++ b/EzyBook/Core/NetworkManager/NetworkService.swift
@@ -11,6 +11,7 @@ import Alamofire
 
 final class NetworkService: NetworkManager {
     
+    
     func request<R: NetworkRouter>(_ router: R, completionHandler: @escaping (Result <Data, APIError>) -> Void) {
         
         do {
@@ -22,20 +23,24 @@ final class NetworkService: NetworkManager {
                     switch response.result {
                     case .success(let data):
                         completionHandler(.success(data))
-                    case .failure:
+                    case .failure(let error):
+                        let responseMessage = response.data
                         if let statusCode = response.response?.statusCode {
-                            let apiError = APIError(statusCode: statusCode)
-                            completionHandler(.failure(apiError))
+                            let error = APIError(statusCode: statusCode, data: responseMessage)
+                            completionHandler(.failure(error))
                         } else {
-                            // 상태코드가 없을 때
-                            completionHandler(.failure(.unknown))
+                            let errorCode = (error as NSError).code
+                            let error = APIError(statusCode: errorCode, data: responseMessage)
+                            completionHandler(.failure(error))
                         }
                     }
                 }
         } catch {
-            completionHandler(.failure(.missingEndpoint))
+            let error = APIError(localErrorType: .missingEndpoint)
+            completionHandler(.failure(error))
         }
         
         
     }
 }
+

--- a/EzyBook/Features/TapView/Profile/View/ProfileView.swift
+++ b/EzyBook/Features/TapView/Profile/View/ProfileView.swift
@@ -41,15 +41,16 @@ struct ProfileView: View {
     }
     private func test() {
         
-        let requestDTO = EmailValidationRequestDTO(email: "sesddddac_re_jack@gmail.com")
+        let requestDTO = EmailValidationRequestDTO(email: "sesac_re_jack@gmail.com")
         let networkRepository = container.makeNetworkRepository()
-        networkRepository.fetchData(dto: EmailValidationResponseDTO.self, UserRequest.emailValidation(body: requestDTO)) { (result: Result<EmailValidationEntity, APIErrorResponse>) in
+        networkRepository.fetchData(dto: EmailValidationResponseDTO.self, UserRequest.emailValidation(body: requestDTO)) { (result: Result<EmailValidationEntity, APIError>) in
             
             switch result {
             case .success(let success):
                 print(success)
             case .failure(let failure):
-                print(failure)
+                print(failure.code)
+                print(failure.userMessage)
             }
         }
         


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #EZB-26

## 📝작업 내용

> 기존에는 에러 발생시, 코드는 보내고 있지만 서버에서오는 json 데이터를 받고 있지 않았음.
> 에러시, Json 데이터 한번에 보낼 수 있게 설계 변경
> API Error을 뷰에서 사용가능하도록 Wrapping해서 보내고 있었던 것을 APIError로 통합
   -> enum내의 각 생성자를 여러개 생성하여 구분 처리

## 💬리뷰 요구사항(선택)
> 지금 에러 메시지에 대한 디코딩은 APIError에서 해주고 있고, 정상 데이터는 NetworkRepository에 해주고 있는데,
> APIError에서 디코딩을 처리하는 것은 단일 책임 원칙의 위배 되지 않을까?
> 또한, 지금 디코딩을 따로따로 처리하고 있는게 과연 최선일까?

## ✅CheckList
- [X] 컨벤션 준수하셨나요?
- [X] 불필요한 주석 제거하셨나요?
- [ ] 단일 책임 원칙을 지키셨나요? -> 다음에 할게요...
