### PR TITLE
Close EZB-51 feat: Keep 기능추가

### DIFF
--- a/EzyBook/Application/DIContainer/AppDIContainer.swift
+++ b/EzyBook/Application/DIContainer/AppDIContainer.swift
@@ -23,8 +23,8 @@ final class AppDIContainer {
     // MARK: - Data Layer
     private let authRepository: DefaultAuthRepository
     private let socialLoginService: DefaultsSocialLoginService
-    
     private let activityRepository: DefaultActivityRepository
+    private let acitvityKeepStatusRepository: DefaultKeepStatusRepository
     
 
 
@@ -41,6 +41,7 @@ final class AppDIContainer {
         socialLoginService = DefaultsSocialLoginService()
         
         activityRepository = DefaultActivityRepository(networkService: networkService)
+        acitvityKeepStatusRepository = DefaultKeepStatusRepository(networkService: networkService)
         
         imageCache = ImageMemoryCache()
         imageLoader = DefaultImageLoader(tokenService: tokenService, imageCache: imageCache, interceptor: interceptor)
@@ -59,6 +60,7 @@ final class AppDIContainer {
             activityNewListUseCase: makeActivityNewListUseCase(),
             activitySearchUseCase: makeActivityNewListUseCase(),
             activityDetailUseCase: makeActivityDetailUseCase(),
+            activityKeepCommandUseCase: makeActivityKeepCommainUseCase(),
             imageLoader: makeImageLoaderUseCase()
         )
     }
@@ -126,5 +128,9 @@ extension AppDIContainer {
     
     private func makeActivityDetailUseCase() -> DefaultActivityDetailUseCase {
         DefaultActivityDetailUseCase(repo: activityRepository)
+    }
+    
+    private func makeActivityKeepCommainUseCase() -> DefaultActivityKeepCommandUseCase {
+        DefaultActivityKeepCommandUseCase(repo: acitvityKeepStatusRepository)
     }
 }

--- a/EzyBook/Application/DIContainer/DIContainer.swift
+++ b/EzyBook/Application/DIContainer/DIContainer.swift
@@ -24,13 +24,14 @@ final class DIContainer: ObservableObject {
     let activityNewListUseCase: DefaultNewActivityListUseCase
     let activitySearchUseCase: DefaultActivitySearchUseCase
     let activityDetailUseCase: DefaultActivityDetailUseCase
+    let activityKeepCommandUseCase: DefaultActivityKeepCommandUseCase
     
     
     /// Common
     let imageLoader: DefaultLoadImageUseCase
 
-    
-    init(kakaoLoginUseCase: DefaultKakaoLoginUseCase, createAccountUseCase: DefaultCreateAccountUseCase, emailLoginUseCase: DefaultEmailLoginUseCase, appleLoginUseCase: DefaultAppleLoginUseCase, activityListUseCase: DefaultActivityListUseCase, activityNewListUseCase: DefaultNewActivityListUseCase, activitySearchUseCase: DefaultActivitySearchUseCase, activityDetailUseCase: DefaultActivityDetailUseCase, imageLoader: DefaultLoadImageUseCase) {
+
+    init(kakaoLoginUseCase: DefaultKakaoLoginUseCase, createAccountUseCase: DefaultCreateAccountUseCase, emailLoginUseCase: DefaultEmailLoginUseCase, appleLoginUseCase: DefaultAppleLoginUseCase, activityListUseCase: DefaultActivityListUseCase, activityNewListUseCase: DefaultNewActivityListUseCase, activitySearchUseCase: DefaultActivitySearchUseCase, activityDetailUseCase: DefaultActivityDetailUseCase, activityKeepCommandUseCase: DefaultActivityKeepCommandUseCase, imageLoader: DefaultLoadImageUseCase) {
         self.kakaoLoginUseCase = kakaoLoginUseCase
         self.createAccountUseCase = createAccountUseCase
         self.emailLoginUseCase = emailLoginUseCase
@@ -39,6 +40,7 @@ final class DIContainer: ObservableObject {
         self.activityNewListUseCase = activityNewListUseCase
         self.activitySearchUseCase = activitySearchUseCase
         self.activityDetailUseCase = activityDetailUseCase
+        self.activityKeepCommandUseCase = activityKeepCommandUseCase
         self.imageLoader = imageLoader
     }
     
@@ -71,6 +73,7 @@ extension DIContainer {
             activityListUseCase: activityListUseCase,
             activityNewLisUsecaset: activityNewListUseCase,
             activityDeatilUseCase: activityDetailUseCase,
+            activityKeepCommandUseCase: activityKeepCommandUseCase,
             imageLoader: imageLoader
         )
     }

--- a/EzyBook/Data/DTO/Activity/ActivityRequestDTO.swift
+++ b/EzyBook/Data/DTO/Activity/ActivityRequestDTO.swift
@@ -22,12 +22,20 @@ struct ActivitySummaryListRequestDTO: Encodable {
 }
 
 /// 액티비티 상세  조회
-/// 액티비티 킵
 struct ActivityDetailRequestDTO: Encodable {
     let activityId: String
     
     enum CodingKeys: String, CodingKey {
          case activityId = "activity_id"
+     }
+}
+
+/// 액티비티 킵
+struct ActivityKeepRequestDTO: Encodable {
+    let status: Bool
+    
+    enum CodingKeys: String, CodingKey {
+         case status = "keep_status"
      }
 }
 

--- a/EzyBook/Data/Remote/Router/Activity/ActivityGetRequest.swift
+++ b/EzyBook/Data/Remote/Router/Activity/ActivityGetRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Alamofire
 
-enum ActivityRequest: GetRouter {
+enum ActivityGetRequest: GetRouter {
     
     case activityFiles
     case activityList(param: ActivitySummaryListRequestDTO)

--- a/EzyBook/Data/Remote/Router/Activity/ActivityPostRequest.swift
+++ b/EzyBook/Data/Remote/Router/Activity/ActivityPostRequest.swift
@@ -1,0 +1,45 @@
+//
+//  ActivityPostRequest.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/31/25.
+//
+
+import Foundation
+import Alamofire
+
+enum ActivityPostRequest: PostRouter {
+   
+    case activityKeep(id: String, param: ActivityKeepRequestDTO)
+ 
+    var requiresAuth: Bool {
+        true
+    }
+    
+    var endpoint: URL? {
+        switch self {
+        case .activityKeep(let id, _):
+            ActivityEndPoint.activityKeep(id: id).requestURL
+        }
+    }
+    
+    var method: HTTPMethod {
+        .post
+    }
+    
+    var requestBody: Encodable? {
+        switch self {
+        case .activityKeep(_, let param):
+            return param
+        }
+    }
+    
+    var headers: HTTPHeaders {
+        [
+            "SeSACKey": APIConstants.apiKey,
+            "Content-Type": "application/json"
+        ]
+        
+    }
+    
+}

--- a/EzyBook/Data/Remote/Router/PostRouter.swift
+++ b/EzyBook/Data/Remote/Router/PostRouter.swift
@@ -12,7 +12,6 @@ import Alamofire
 /// Post 전용
 protocol PostRouter: NetworkRouter {
     var requestBody: Encodable? { get }
-    //var encoder: URLQueryEncoder { get }
     var bodyEncoder: JSONEncoder { get }
     func encodeBody(for request: URLRequest) throws -> URLRequest
 }
@@ -25,12 +24,12 @@ extension PostRouter {
     
     /// POST 요청 특화 처리 (body)
     func encodeBody(for request: URLRequest) throws -> URLRequest {
-        guard let body = requestBody else {
-            throw APIError(localErrorType: .missingRequestBody)
-        }
 
         var request = request
-        request.httpBody = try bodyEncoder.encode(body)
+        
+        if let body = requestBody {
+            request.httpBody = try bodyEncoder.encode(body)
+        }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         return request//try encoder.encode(request: request, with: body)

--- a/EzyBook/Data/Remote/Supports/ResponseDecoder.swift
+++ b/EzyBook/Data/Remote/Supports/ResponseDecoder.swift
@@ -11,6 +11,11 @@ import Foundation
 struct ResponseDecoder {
     func decode<T: Decodable>(data: Data, type: T.Type) -> Result<T, APIError> {
         do {
+            /// 나중에 테스트 해볼 것
+            //let test = JSONDecoder()
+            //test.keyDecodingStrategy = .convertFromSnakeCase
+            // let decoded = try JSONDecoder().decode(T.self, from: data)
+            //decoder.keyDecodingStrategy = .convertFromSnakeCase
             let decoded = try JSONDecoder().decode(T.self, from: data)
             return .success(decoded)
         } catch {

--- a/EzyBook/Data/Repositories/DefaultActivityRepository.swift
+++ b/EzyBook/Data/Repositories/DefaultActivityRepository.swift
@@ -20,19 +20,19 @@ final class DefaultActivityRepository: ActivityListRepository, ActivityQueryRepo
     }
     
     /// 액티비티 목록 조회
-    func requestActivityList(_ router: ActivityRequest) async throws -> ActivitySummaryListEntity {
+    func requestActivityList(_ router: ActivityGetRequest) async throws -> ActivitySummaryListEntity {
         let data = try await networkService.fetchData(dto: ActivitySummaryListResponseDTO.self, router)
         return data.toEntity()
     }
     
     /// 신규 액티비티 목록 조회
     /// 액티비티 검색 결과
-    func requestActivityNewList(_ router: ActivityRequest) async throws -> [ActivitySummaryEntity] {
+    func requestActivityNewList(_ router: ActivityGetRequest) async throws -> [ActivitySummaryEntity] {
         let data = try await networkService.fetchData(dto: ActivityListResponseDTO.self, router)
         return data.toEntity()
     }
     
-    func requestActivityDetail(_ router: ActivityRequest) async throws -> ActivityDetailEntity {
+    func requestActivityDetail(_ router: ActivityGetRequest) async throws -> ActivityDetailEntity {
         let data = try await networkService.fetchData(dto: ActivityDetailResponseDTO.self, router)
         
         return data.toEntity()

--- a/EzyBook/Data/Repositories/DefaultKeepStatusRepository.swift
+++ b/EzyBook/Data/Repositories/DefaultKeepStatusRepository.swift
@@ -1,0 +1,31 @@
+//
+//  DefaultKeepStatusRepository.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/31/25.
+//
+
+import Foundation
+
+
+/// 해당 상태는 문제
+struct DefaultKeepStatusRepository: ActivityKeepCommandRepository,  ActivityKeepQueryRepository {
+    
+    private let networkService: NetworkService
+    
+    init(networkService: NetworkService) {
+        self.networkService = networkService
+    }
+    
+    /// 킵 요청
+    func requestToggleKeep(_ router: ActivityPostRequest) async throws -> ActivityKeepEntity  {
+        
+        let data = try await networkService.fetchData(dto: ActivityKeepResponseDTO.self, router)
+        
+        return data.toEntity()
+        
+    }
+    
+    //TODO: Keep list 조회
+}
+

--- a/EzyBook/Domain/Interfaces/Activity/ActivityDetailRepository.swift
+++ b/EzyBook/Domain/Interfaces/Activity/ActivityDetailRepository.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol ActivityDetailRepository {
-    func requestActivityDetail(_ router: ActivityRequest) async throws -> ActivityDetailEntity
+    func requestActivityDetail(_ router: ActivityGetRequest) async throws -> ActivityDetailEntity
 }

--- a/EzyBook/Domain/Interfaces/Activity/ActivityKeepCommandRepository.swift
+++ b/EzyBook/Domain/Interfaces/Activity/ActivityKeepCommandRepository.swift
@@ -1,0 +1,12 @@
+//
+//  ActivityKeepCommandRepository.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/31/25.
+//
+
+import Foundation
+
+protocol ActivityKeepCommandRepository {
+    func requestToggleKeep(_ router: ActivityPostRequest) async throws -> ActivityKeepEntity 
+}

--- a/EzyBook/Domain/Interfaces/Activity/ActivityKeepQueryRepository.swift
+++ b/EzyBook/Domain/Interfaces/Activity/ActivityKeepQueryRepository.swift
@@ -1,0 +1,12 @@
+//
+//  ActivityKeepQueryRepository.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/31/25.
+//
+
+import Foundation
+
+protocol ActivityKeepQueryRepository {
+    
+}

--- a/EzyBook/Domain/Interfaces/Activity/ActivityListRepository.swift
+++ b/EzyBook/Domain/Interfaces/Activity/ActivityListRepository.swift
@@ -9,5 +9,5 @@ import Foundation
 
 /// 액티비티 목록 조회
 protocol ActivityListRepository {
-    func requestActivityList(_ router: ActivityRequest) async throws -> ActivitySummaryListEntity
+    func requestActivityList(_ router: ActivityGetRequest) async throws -> ActivitySummaryListEntity
 }

--- a/EzyBook/Domain/Interfaces/Activity/ActivityQueryRepository.swift
+++ b/EzyBook/Domain/Interfaces/Activity/ActivityQueryRepository.swift
@@ -9,5 +9,5 @@ import Foundation
 
 /// 신규 액티비티 및 액티비티 검색 공용
 protocol ActivityQueryRepository {
-    func requestActivityNewList(_ router: ActivityRequest) async throws -> [ActivitySummaryEntity]
+    func requestActivityNewList(_ router: ActivityGetRequest) async throws -> [ActivitySummaryEntity]
 }

--- a/EzyBook/Domain/Usecases/Activity/DefaultActivityDetailUseCase.swift
+++ b/EzyBook/Domain/Usecases/Activity/DefaultActivityDetailUseCase.swift
@@ -22,7 +22,7 @@ extension DefaultActivityDetailUseCase {
     func execute(id: String) async throws -> ActivityDetailEntity {
         let requestDto = ActivityDetailRequestDTO(activityId: id)
         
-        let router = ActivityRequest.activityDetail(param: requestDto)
+        let router = ActivityGetRequest.activityDetail(param: requestDto)
         
         do {
             let data = try await repo.requestActivityDetail(router)

--- a/EzyBook/Domain/Usecases/Activity/DefaultActivityListUseCase.swift
+++ b/EzyBook/Domain/Usecases/Activity/DefaultActivityListUseCase.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Combine
 
 final class DefaultActivityListUseCase {
     
@@ -16,14 +15,9 @@ final class DefaultActivityListUseCase {
         self.repo = repo
     }
     
-    
-}
-
-extension DefaultActivityListUseCase {
-    
     func execute(requestDto: ActivitySummaryListRequestDTO) async throws -> ActivitySummaryListEntity {
         
-        let router = ActivityRequest.activityList(param: requestDto)
+        let router = ActivityGetRequest.activityList(param: requestDto)
         
         do {
             /// await: 결과 대기
@@ -39,7 +33,4 @@ extension DefaultActivityListUseCase {
             
         }
     }
-    
 }
-
-

--- a/EzyBook/Domain/Usecases/Activity/DefaultActivitySearchUseCase.swift
+++ b/EzyBook/Domain/Usecases/Activity/DefaultActivitySearchUseCase.swift
@@ -15,17 +15,12 @@ final class DefaultActivitySearchUseCase {
         self.repo = repo
     }
     
-    
-}
-
-extension DefaultActivitySearchUseCase {
-    
     func execute(title: String,  completionHandler: @escaping (Result <[ActivitySummaryEntity], APIError>) -> Void) {
 
         
         let requestDto = ActivitySearchListRequestDTO(title: title)
         
-        let router = ActivityRequest.serachActiviy(param: requestDto)
+        let router = ActivityGetRequest.serachActiviy(param: requestDto)
         
         Task {
             do {
@@ -49,3 +44,4 @@ extension DefaultActivitySearchUseCase {
         }
     }
 }
+

--- a/EzyBook/Domain/Usecases/Activity/DefaultNewActivityListUseCase.swift
+++ b/EzyBook/Domain/Usecases/Activity/DefaultNewActivityListUseCase.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Combine
 
 final class DefaultNewActivityListUseCase {
     
@@ -16,15 +15,9 @@ final class DefaultNewActivityListUseCase {
         self.repo = repo
     }
     
-    
-}
-
-
-extension DefaultNewActivityListUseCase {
-
     func execute(country: String?, category: String?) async throws -> [ActivitySummaryEntity] {
         let requestDto = ActivityNewSummaryListRequestDTO(country: country, category: category)
-        let router = ActivityRequest.newActivities(param: requestDto)
+        let router = ActivityGetRequest.newActivities(param: requestDto)
 
         do {
             return try await repo.requestActivityNewList(router)
@@ -36,4 +29,6 @@ extension DefaultNewActivityListUseCase {
             }
         }
     }
+    
 }
+

--- a/EzyBook/Domain/Usecases/Common/DefaultActivityKeepCommandUseCase.swift
+++ b/EzyBook/Domain/Usecases/Common/DefaultActivityKeepCommandUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  DefaultActivityKeepCommandUseCase.swift
+//  EzyBook
+//
+//  Created by youngkyun park on 5/31/25.
+//
+
+import Foundation
+
+final class DefaultActivityKeepCommandUseCase {
+    
+    private let repo: ActivityKeepCommandRepository
+    
+    init(repo: ActivityKeepCommandRepository) {
+        self.repo = repo
+    }
+    
+    func execute(id: String, stauts: Bool) async throws -> ActivityKeepEntity {
+
+        let dto = ActivityKeepRequestDTO(status: stauts)
+        let router = ActivityPostRequest.activityKeep(id: id, param: dto)
+        do {
+            return try await repo.requestToggleKeep(router)
+        } catch {
+            if let apiError = error as? APIError {
+                throw apiError
+            } else {
+                throw APIError.unknown
+            }
+        }
+    }
+}
+

--- a/EzyBook/PreViewHelper/PreViewHelper.swift
+++ b/EzyBook/PreViewHelper/PreViewHelper.swift
@@ -25,13 +25,13 @@ enum PreViewHelper {
     
     static let imageLoader = DefaultImageLoader(tokenService: tokenService, imageCache: imageCache, interceptor: interceptor)
     
-    static let  authRepository = DefaultAuthRepository(networkService: networkService)
-    static let  socialLoginService = DefaultsSocialLoginService()
+    static let authRepository = DefaultAuthRepository(networkService: networkService)
+    static let socialLoginService = DefaultsSocialLoginService()
     
-    static let  activityRepository = DefaultActivityRepository(networkService: networkService)
+    static let activityRepository = DefaultActivityRepository(networkService: networkService)
     
-    static let  newActivityRepository = DefaultActivityRepository(networkService: networkService)
-    
+    static let newActivityRepository = DefaultActivityRepository(networkService: networkService)
+    static let acitvityKeepStatusRepository =  DefaultKeepStatusRepository(networkService: networkService)
     // MARK: - Data Layer
     
     static let diContainer = DIContainer(
@@ -43,6 +43,7 @@ enum PreViewHelper {
         activityNewListUseCase: makeActivityNewListUseCase(),
         activitySearchUseCase: makeActivitySearchUseCase(),
         activityDetailUseCase: makeActivityDetailUseCase(),
+        activityKeepCommandUseCase: makeActivityKeepCommainUseCase(),
         imageLoader: makeImageLoaderUseCase()
     )
     
@@ -132,6 +133,10 @@ extension PreViewHelper {
     
     static func makeActivityDetailUseCase() -> DefaultActivityDetailUseCase {
         DefaultActivityDetailUseCase(repo: activityRepository)
+    }
+    
+    static func makeActivityKeepCommainUseCase() -> DefaultActivityKeepCommandUseCase {
+        DefaultActivityKeepCommandUseCase(repo: acitvityKeepStatusRepository)
     }
 
 }

--- a/EzyBook/Presentation/Common/Component/ActivityIntroduceView.swift
+++ b/EzyBook/Presentation/Common/Component/ActivityIntroduceView.swift
@@ -12,7 +12,7 @@ struct ActivityIntroduceView: View {
     
     @Binding var data: [FilterActivityModel]
     
-    var onTapKeep: (String) -> Void
+    var onTapKeep: (Int) -> Void
     var currentIndex: (Int) -> Void
     
     var body: some View {
@@ -26,7 +26,8 @@ struct ActivityIntroduceView: View {
             LazyVStack {
                 ForEach(Array(zip(data.indices, data)), id: \.1.activityID) { index, item in
                     VStack {
-                        makeFilterImageView(item)
+                        //Text(item.activityID) // 중복 확인
+                        makeFilterImageView(index, item)
                         makedescriptionView(item)
                     }
                     .onAppear {
@@ -42,7 +43,7 @@ struct ActivityIntroduceView: View {
 
 extension ActivityIntroduceView {
     
-    private func makeFilterImageView(_ item: FilterActivityModel) -> some View {
+    private func makeFilterImageView(_ index: Int, _ item: FilterActivityModel) -> some View {
         GeometryReader { geo in
             ZStack() {
                 Image(uiImage: item.thumnail)
@@ -53,7 +54,7 @@ extension ActivityIntroduceView {
                     .background(.red)
                     .clipShape(RoundedRectangle(cornerRadius: 15))
                 
-                makeBadgeView(item)
+                makeBadgeView(index, item)
                 
                 if let tag = item.eventTag {
                     VStack {
@@ -70,13 +71,14 @@ extension ActivityIntroduceView {
         .padding(.horizontal, 10)
     }
     
-    private func makeBadgeView(_ item: FilterActivityModel) -> some View {
+    private func makeBadgeView(_ index: Int, _ item: FilterActivityModel) -> some View {
         VStack {
             VStack(alignment: .leading, spacing: 10) {
                 
                 HStack(alignment: .center, spacing: 0) {
                     ActivityKeepButtonView(isKeep: item.isKeep) {
-                        onTapKeep(item.activityID)
+                        /// 뷰모델에서 contain보다는, 인덱스 기반으로 찾는게 시간복잡도가 O(1)이기 때문에, 인덱스를 보냄
+                        onTapKeep(index)
                     }
                     Spacer()
                     LocationTagView(country: item.country)

--- a/EzyBook/Presentation/Home/HomeView.swift
+++ b/EzyBook/Presentation/Home/HomeView.swift
@@ -33,8 +33,8 @@ struct HomeView: View {
                     makeNewActivityView()
                     makeFlagSelectionView()
                     makeFilterSelectionView()
-                    ActivityIntroduceView(data: $viewModel.output.filterActivityDetailList) { id in
-                        print("뷰모델 작업")
+                    ActivityIntroduceView(data: $viewModel.output.filterActivityDetailList) { index in
+                        viewModel.action(.keepButtonTapped(index: index))
                     } currentIndex: { index in
                         viewModel.action(.prefetchfilterActivityContent(index: index))
                         viewModel.action(.paginationAcitiviyList(flag: selectedFlag, filter: selectedFilter, index: index))

--- a/EzyBook/Presentation/Home/Models/ActivityModels.swift
+++ b/EzyBook/Presentation/Home/Models/ActivityModels.swift
@@ -53,7 +53,7 @@ struct FilterActivityModel: ActivityModelBuildable {
     let finalPrice: Int
     let pointReward: Int? // 액티비티 포인트 리워드
     let isAdvertisement: Bool //광고 여부
-    let isKeep: Bool // 현재 유저의 킵 여부
+    var isKeep: Bool // 현재 유저의 킵 여부
     let keepCount: Int // 이 액티비티의 총 킵 수
     let endDate: String?
     


### PR DESCRIPTION
## #️⃣연관된 이슈

> EZB-51

## 📝작업 내용

> 좋아요 기능 추가
-  서버 통신 기준이 아닌, 유저의 버튼 상태에 따라서 먼저 UI업데이트를 진행하고, 이후 서버 결과에 따른 UI 상태처리
- 서버 결과에 따른 상태처리를 한 번 더 하는 이유는 실패도 있겠지만, 디바이스 기기간 동기화를 위해서 처리
- 서버 요청를 통해서 request를 관리 하지 않는다면, 디바이스간 동기화가 안될 수 있음
ex). 유저의 상태로만 체크할경우, 실패에 대한 대응이 어렵고, 다른 디바이스의 대한 상태 동기화가 안될 수 있음

## ✅CheckList
- [X] 컨벤션 준수하셨나요?
- [X] 불필요한 주석 제거하셨나요?
